### PR TITLE
Adding multi-network support when adding a VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,53 @@
 Role Name
 =========
 
-A brief description of the role goes here.
-
-Requirements
-------------
-
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+Provide a role to create VM on VMware Vcenter or standalone ESXi from a OVA file
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
-
-Dependencies
-------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+	ovftool_path
+	vcenter
+	vcenter_user
+	vcenter_password
+	datacenter
+	cluster
+	datastore
+	portgroup
+	vm_name
+	path_to_ova
+	ova_file
+	power_on
+	ssl_verify
+	vm_password_key
+	vm_password
+	props
+	deployment_option
+	ovf_network_name
+	vcenter_folder
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+To use in your playbook:
 
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
-
-License
--------
-
-BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+- name: Create OVA VM
+  include_role:
+    name: ovftool
+  vars:
+    ovftool_path: '/usr/bin'
+    vcenter: 'my_esxi_host'
+    vcenter_user: 'my_esxi_username'
+    vcenter_password: 'my_esxi_password'
+    datacenter: ''
+    cluster: ''
+    datastore: 'datastore1'
+    portgroup: ''
+    vm_name: 'my_new_vm'
+    path_to_ova: '/tmp/'
+    ova_file: 'test.ova'
+    power_on: true
+    ssl_verify: false
+    ovf_network_name:
+      ova_network1: 'my_esxi_network1'
+      ova_network2: 'my_esxi_network1'

--- a/library/ovftool.py
+++ b/library/ovftool.py
@@ -5,6 +5,7 @@ __author__ = 'pacogomez'
 import atexit
 import ssl
 import urllib
+import json
 
 import requests
 from ansible.module_utils.basic import *
@@ -105,8 +106,13 @@ def main():
         '--name={}'.format(module.params['vm_name']), ])
 
     if 'ovf_network_name' in module.params.keys() and module.params['ovf_network_name'] is not None and len(
-            module.params['ovf_network_name']) > 0:
-        command_tokens.append('--net:{}={}'.format(module.params['ovf_network_name'], module.params['portgroup']))
+                module.params['ovf_network_name']) > 0:
+            try:
+                d=json.loads(module.params['ovf_network_name'].replace("'", "\""))
+                for key,network_item in d.iteritems():
+                    command_tokens.append('--net:{}={}'.format(key, network_item))
+            except ValueError, e:
+                command_tokens.append('--net:{}={}'.format(module.params['ovf_network_name'], module.params['portgroup']))
     else:
         command_tokens.append('--network={}'.format(module.params['portgroup']))
 


### PR DESCRIPTION
Adding multi-network port group support.

If your OVA VM has several network interfaces, you can use the variable ovf_network_name in json format:
``ovf_network_name: { vm_network1: "esxi_network_wan", vm_network2 : "esxi_network_lan" }``

If your OVA VM has only one interface, you can still use variables portgroup and ovf_network_name:
 ``ovf_network_name: "esxi_network_wan"``