### PR TITLE
Add ovftool debug command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,31 @@ To use in your playbook:
       ova_network1: 'my_esxi_network1'
       ova_network2: 'my_esxi_network1'
 ```
+
+A URL can be used instead of a local path and file by setting the `path_to_ova` to the path portion of the URL.  For instance, updating the above example to use a URL looks something like this:
+
+```
+- name: Create OVA VM
+  include_role:
+    name: ovftool
+  vars:
+    ...
+    ova_path: 'https://some.hostname.com/path/to/ova'
+    ova_filename: 'ova_file.ova'
+    ...
+```
+
+Additional debugging produced by the `ovftool` can be enabled bu adding the `debug_opts:` flag like this:
+```
+- name: Create OVA VM
+  include_role:
+    name: ovftool
+  vars:
+    ...
+    debug_opts:
+      logFile: 'ovftool-1.log'
+      logLevel: 'verbose'
+    ...
+```
+
+**NOTE:** Currently this will place the resulting log files in the directory the playbook is run when executed with `connection: local` set.

--- a/library/ovftool.py
+++ b/library/ovftool.py
@@ -54,6 +54,7 @@ def main():
             cluster=dict(required=True, type='str'),
             datastore=dict(required=True, type='str'),
             ovf_network_name=dict(required=False, type='str'),
+            debug_opts=dict(required=False, type='str'),
             portgroup=dict(required=True, type='str'),
             disk_mode=dict(required=False, type='str', default='thin'),
             path_to_ova=dict(required=True, type='str'),
@@ -126,6 +127,13 @@ def main():
         command_tokens.append('--deploymentOption={}'.format(module.params['deployment_option']))
     if 'vcenter_folder' in module.params and module.params['vcenter_folder'] is not None:
         command_tokens.append('--vmFolder={}'.format(module.params['vcenter_folder']))
+
+    if 'debug_opts' in module.params.keys() and module.params['debug_opts'] is not None and len(module.params['debug_opts']) > 0:
+        d=json.loads(module.params['debug_opts'].replace("'", "\""))
+        for key,debug_item in d.iteritems():
+            command_tokens.append('--X:{}={}'.format(key, debug_item))
+    else:
+        command_tokens.append('--X:{}'.format(module.params['debug_opts']))
 
     command_tokens.extend([ova_file, vi_string])
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,4 +18,5 @@
     props: '{{ props | default (dict()) }}'
     deployment_option: '{{ deployment_option | default() }}'
     ovf_network_name: '{{ ovf_network_name | default() }}'
+    debug_opts: '{{ debug_opts | default() }}'
     vcenter_folder: '{{ vcenter_folder | default() }}'


### PR DESCRIPTION
I've added code to permit the addition of the ovftools "--X" debug options. This is extremely useful in debugging communications errors - the generic error message is not sufficient, the log files contain the details (e.g. the name of the hypervisor, etc).